### PR TITLE
Fixed executor runtime image base

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ kubectl apply -f examples/zap-executor.yaml
 Issue the following commands to create and start a ZAP test for a given YAML configuration file:
 ```bash
 kubectl testkube create test --filename examples/zap-api.yaml --type "zap/api" --name api-test
-kubectl testkube run run --watch api-test
+kubectl testkube run test --watch api-test
 
 kubectl testkube create test --filename examples/zap-baseline.yaml --type "zap/baseline" --name baseline-test
 kubectl testkube run test --watch baseline-test

--- a/build/agent/Dockerfile
+++ b/build/agent/Dockerfile
@@ -7,8 +7,7 @@ ENV GOOS=linux
 
 RUN cd cmd/agent;go build -o /runner -mod mod -a .
 
-FROM alpine
-RUN apk --no-cache add ca-certificates
-WORKDIR /root/
+FROM owasp/zap2docker-stable:2.12.0
+ENV ZAP_HOME /zap
 COPY --from=0 /runner /bin/runner
 ENTRYPOINT ["/bin/runner"]

--- a/examples/zap-executor.yaml
+++ b/examples/zap-executor.yaml
@@ -7,13 +7,8 @@ spec:
   executor_type: job
   image: kubeshop/testkube-zap-executor:latest
   types:
-  - zap/api
-  - zap/baseline
-  - zap/full
-  #contentTypes:
-  # - "string"
-  # - file-uri
-  # - git-file
-  # - git-dir
+    - zap/api
+    - zap/baseline
+    - zap/full
   features:
     - artifacts


### PR DESCRIPTION
## Pull request description 

The executor runtime image used alpine as base image. However, we need to use the official ZAP docker image as base for this executor instead!

## Checklist (choose whats happened)

- [X] tested locally
- [X] tested on cluster
- [X] updated the docs

## Fixes

- Fixed wrong base image for final executor runtime image. Use `owasp/zap2docker-stable:2.12.0` instead.